### PR TITLE
Radio scale to redux

### DIFF
--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -11,3 +11,6 @@ export const getCatcallsSuccess = data => ({
   type: "GET_CATCALLS_SUCCESS",
   payload: data
 });
+
+// FORM RADIO SCALE
+export const SELECTED_RATING = "SELECTED_RATING";

--- a/src/store/actions/radioScaleActions.js
+++ b/src/store/actions/radioScaleActions.js
@@ -1,0 +1,7 @@
+import * as types from "./index";
+
+export const selectedRating = rating =>
+({
+  type: types.SELECTED_RATING,
+  rating
+})

--- a/src/store/actions/radioScaleActions.js
+++ b/src/store/actions/radioScaleActions.js
@@ -1,7 +1,6 @@
 import * as types from "./index";
 
-export const selectedRating = rating =>
-({
+export const selectedRating = rating => ({
   type: types.SELECTED_RATING,
   rating
-})
+});

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from "redux";
 import { connectRouter } from "connected-react-router";
 import map from "./mapReducer";
+import radioScale from "./radioScaleReducer";
 
 const catcalls = (state = [], action) => {
   if (action.type === "GET_CATCALLS_SUCCESS") {
@@ -14,5 +15,6 @@ export default history =>
   combineReducers({
     router: connectRouter(history),
     map,
-    catcalls
+    catcalls,
+    radioScale
   });

--- a/src/store/reducers/radioScaleReducer.js
+++ b/src/store/reducers/radioScaleReducer.js
@@ -1,0 +1,19 @@
+import * as types from "../actions";
+
+const initialState = {
+  selectedRating: null
+}
+
+export default (state = initialState, action) => {
+  switch(action.type) {
+    case types.SELECTED_RATING: {
+      return {
+        ...state,
+        selectedRating: action.selectedRating
+      }
+    }
+    default: {
+      return state
+    }
+  }
+}

--- a/src/store/reducers/radioScaleReducer.js
+++ b/src/store/reducers/radioScaleReducer.js
@@ -2,18 +2,18 @@ import * as types from "../actions";
 
 const initialState = {
   selectedRating: null
-}
+};
 
 export default (state = initialState, action) => {
-  switch(action.type) {
+  switch (action.type) {
     case types.SELECTED_RATING: {
       return {
         ...state,
         selectedRating: action.selectedRating
-      }
+      };
     }
     default: {
-      return state
+      return state;
     }
   }
-}
+};


### PR DESCRIPTION
Purpose: to connect the radio scale inputs to the redux store. We will collect all the information from the form and then send them to the backend when the user submits their report.