### PR TITLE
adding one marker to the map

### DIFF
--- a/src/components/map/MapContainer.js
+++ b/src/components/map/MapContainer.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { GoogleApiWrapper, Map } from "google-maps-react";
+import { GoogleApiWrapper, Map, Marker } from "google-maps-react";
 import { DisplayAddress } from "./DisplayAddress";
 
 class MapContainer extends Component {
@@ -79,7 +79,14 @@ class MapContainer extends Component {
             google={this.props.google}
             initialCenter={this.state.currentLocation}
             onDragend={(mapProps, map) => this.centerMoved(mapProps, map)}
-          />
+          >
+            <Marker
+              title={'MYCURRENTLOCATION'}
+              name={'MYCURRENTLOCATION'}
+              position={this.state.centerMarker}
+            />
+
+          </Map>
         )}
       </div>
     );


### PR DESCRIPTION
this pr will only display one marker on the map, first at the current location, then once the map is moved it will stay in the middle of the map and the map will sort of move behind it (per the ticket, the functionality should be the same as in uber). 
