### PR TITLE
Route to views

### DIFF
--- a/src/components/views/ReportIncident.js
+++ b/src/components/views/ReportIncident.js
@@ -69,12 +69,6 @@ class ReportIncident extends Component {
   }
 }
 
-// const mapStateToProps = store => ({
-//   lat: store.map.centerMarker.lat,
-//   lng: store.map.centerMarker.lng,
-//   address: store.map.address
-// });
-
 const mapDispatchToProps = {
   submitForm
 };

--- a/src/store/actions/incidentsActions.js
+++ b/src/store/actions/incidentsActions.js
@@ -46,9 +46,7 @@ export const submitForm = selectedInput => async (dispatch, getState) => {
       textLocation: getState().map.address
     };
     const resp = await apiPostForm(formData);
-    return dispatch(submitFormSuccess(resp)).then(() =>
-      dispatch(push("/view-reports"))
-    );
+    return dispatch(submitFormSuccess(resp)) && dispatch(push("/view-reports"));
   } catch (e) {
     return dispatch(submitFormFailure(true));
   }


### PR DESCRIPTION
This PR satisfies the requirements of Trello ticket: 3.1.2 the button also takes the user to the next screen.

Previously this functionality was broken because the .then() that was dispatching the new route was not running, because it was happening after something was being returned, so it was never reached.

*This way of routing creates/or exposes a bug though, where Views page is loaded before it has access to the previous incidents. Working on a fix for this, to follow in another PR.